### PR TITLE
envoy-sdk-test: add `FakeClock` API

### DIFF
--- a/envoy-sdk-test/src/host/mod.rs
+++ b/envoy-sdk-test/src/host/mod.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![doc(html_root_url = "https://docs.rs/envoy-sdk-test/0.0.1")]
+//! Fake `Envoy` `Host APIs` for use in unit tests.
 
-pub use self::host::*;
+pub use time::FakeClock;
 
-pub mod host;
+pub mod time;

--- a/envoy-sdk-test/src/host/time.rs
+++ b/envoy-sdk-test/src/host/time.rs
@@ -1,0 +1,180 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Fake `Time API`.
+//!
+//! # Examples
+//!
+//! #### Basic usage of [`FakeClock`]:
+//!
+//! ```
+//! # use envoy_sdk_test as envoy_test;
+//! use std::time::{Duration, SystemTime};
+//! use envoy::host::Clock;
+//! use envoy_test::FakeClock;
+//!
+//! # fn main() -> envoy::host::Result<()> {
+//! let clock = FakeClock::default();
+//!
+//! assert_eq!(clock.now()?, SystemTime::UNIX_EPOCH);
+//! assert_eq!(clock.now()?, SystemTime::UNIX_EPOCH);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! #### Setting a time of the [`FakeClock`]:
+//!
+//! ```
+//! # use envoy_sdk_test as envoy_test;
+//! use std::time::{Duration, SystemTime};
+//! use envoy::host::Clock;
+//! use envoy_test::FakeClock;
+//!
+//! # fn main() -> envoy::host::Result<()> {
+//! let mut clock = FakeClock::default();
+//!
+//! let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(5);
+//!
+//! clock.freeze_at(t0);
+//!
+//! assert_eq!(clock.now()?, t0);
+//! assert_eq!(clock.now()?, t0);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! #### Setting a sequence of time values of the [`FakeClock`]:
+//!
+//! ```
+//! # use envoy_sdk_test as envoy_test;
+//! use std::time::{Duration, SystemTime};
+//! use envoy::host::Clock;
+//! use envoy_test::FakeClock;
+//!
+//! # fn main() -> envoy::host::Result<()> {
+//! let mut clock = FakeClock::default();
+//!
+//! let t0 = SystemTime::UNIX_EPOCH;
+//! let moments = (0..).map(move |i| t0 + Duration::from_secs(i));
+//!
+//! clock.tick_at(moments);
+//!
+//! assert_eq!(clock.now()?, t0);
+//! assert_eq!(clock.now()?, t0 + Duration::from_secs(1));
+//! assert_eq!(clock.now()?, t0 + Duration::from_secs(2));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`FakeClock`]: struct.FakeClock.html
+
+use std::cell::RefCell;
+use std::iter;
+use std::time::SystemTime;
+
+use envoy::error::format_err;
+use envoy::host::time::Clock;
+use envoy::host::Result;
+
+/// Fake `System Clock`.
+pub struct FakeClock(RefCell<Box<dyn Iterator<Item = SystemTime>>>);
+
+impl Clock for FakeClock {
+    /// Returns current system time.
+    fn now(&self) -> Result<SystemTime> {
+        self.0
+            .borrow_mut()
+            .next()
+            .ok_or_else(|| format_err!("no more ticks"))
+    }
+}
+
+impl Default for FakeClock {
+    /// Returns a clock freezed at [`UNIX_EPOCH`] time.
+    ///
+    /// [`UNIX_EPOCH`]: https://doc.rust-lang.org/std/time/constant.UNIX_EPOCH.html
+    fn default() -> Self {
+        FakeClock::new(iter::repeat(SystemTime::UNIX_EPOCH))
+    }
+}
+
+impl FakeClock {
+    fn new<T>(ticker: T) -> Self
+    where
+        T: IntoIterator<Item = SystemTime>,
+        T::IntoIter: 'static,
+    {
+        FakeClock(RefCell::new(Box::new(ticker.into_iter())))
+    }
+
+    /// Sets a time value to be returned by the subsequent calls to `now()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use envoy_sdk_test as envoy_test;
+    /// use std::time::{Duration, SystemTime};
+    /// use envoy::host::Clock;
+    /// use envoy_test::FakeClock;
+    ///
+    /// # fn main() -> envoy::host::Result<()> {
+    /// let mut clock = FakeClock::default();
+    ///
+    /// let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(5);
+    ///
+    /// clock.freeze_at(t0);
+    ///
+    /// assert_eq!(clock.now()?, t0);
+    /// assert_eq!(clock.now()?, t0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn freeze_at(&self, time: SystemTime) -> &Self {
+        drop(self.0.replace(Box::new(iter::repeat(time))));
+        self
+    }
+
+    /// Sets a sequence of time values to be returned by the subsequent calls to `now()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use envoy_sdk_test as envoy_test;
+    /// use std::time::{Duration, SystemTime};
+    /// use envoy::host::Clock;
+    /// use envoy_test::FakeClock;
+    ///
+    /// # fn main() -> envoy::host::Result<()> {
+    /// let mut clock = FakeClock::default();
+    ///
+    /// let t0 = SystemTime::UNIX_EPOCH;
+    /// let moments = (0..).map(move |i| t0 + Duration::from_secs(i));
+    ///
+    /// clock.tick_at(moments);
+    ///
+    /// assert_eq!(clock.now()?, t0);
+    /// assert_eq!(clock.now()?, t0 + Duration::from_secs(1));
+    /// assert_eq!(clock.now()?, t0 + Duration::from_secs(2));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn tick_at<T>(&self, ticker: T) -> &Self
+    where
+        T: IntoIterator<Item = SystemTime>,
+        T::IntoIter: 'static,
+    {
+        drop(self.0.replace(Box::new(ticker.into_iter())));
+        self
+    }
+}

--- a/envoy-sdk-test/src/host/time.rs
+++ b/envoy-sdk-test/src/host/time.rs
@@ -20,7 +20,7 @@
 //!
 //! ```
 //! # use envoy_sdk_test as envoy_test;
-//! use std::time::{Duration, SystemTime};
+//! use std::time::SystemTime;
 //! use envoy::host::Clock;
 //! use envoy_test::FakeClock;
 //!

--- a/envoy-sdk-test/src/host/time.rs
+++ b/envoy-sdk-test/src/host/time.rs
@@ -81,8 +81,7 @@
 use std::cell::RefCell;
 use std::time::{Duration, SystemTime};
 
-use envoy::host::time::Clock;
-use envoy::host::Result;
+use envoy::host::{Clock, Result};
 
 /// Fake `System Clock`.
 pub struct FakeClock(RefCell<SystemTime>);

--- a/envoy-sdk-test/tests/host/mod.rs
+++ b/envoy-sdk-test/tests/host/mod.rs
@@ -12,8 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![doc(html_root_url = "https://docs.rs/envoy-sdk-test/0.0.1")]
-
-pub use self::host::*;
-
-pub mod host;
+mod time;

--- a/envoy-sdk-test/tests/host/time.rs
+++ b/envoy-sdk-test/tests/host/time.rs
@@ -20,7 +20,7 @@ use envoy_sdk_test as envoy_test;
 use envoy_test::FakeClock;
 
 #[test]
-fn test_fake_clock() -> Result<()> {
+fn test_default_fake_clock() -> Result<()> {
     let clock = FakeClock::default();
 
     assert_eq!(clock.now()?, SystemTime::UNIX_EPOCH);
@@ -31,11 +31,9 @@ fn test_fake_clock() -> Result<()> {
 
 #[test]
 fn test_fake_clock_at_given_time() -> Result<()> {
-    let clock = FakeClock::default();
-
     let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(5);
 
-    clock.freeze_at(t0);
+    let clock = FakeClock::new(t0);
 
     assert_eq!(clock.now()?, t0);
     assert_eq!(clock.now()?, t0);
@@ -44,17 +42,18 @@ fn test_fake_clock_at_given_time() -> Result<()> {
 }
 
 #[test]
-fn test_fake_clock_at_given_times() -> Result<()> {
+fn test_advance_fake_clock() -> Result<()> {
     let clock = FakeClock::default();
 
-    let t0 = SystemTime::UNIX_EPOCH;
-    let moments = (0..).map(move |i| t0 + Duration::from_secs(i));
+    assert_eq!(clock.now()?, SystemTime::UNIX_EPOCH);
+    assert_eq!(clock.now()?, SystemTime::UNIX_EPOCH);
 
-    clock.tick_at(moments);
+    clock.advance(Duration::from_secs(3));
 
-    assert_eq!(clock.now()?, t0);
-    assert_eq!(clock.now()?, t0 + Duration::from_secs(1));
-    assert_eq!(clock.now()?, t0 + Duration::from_secs(2));
+    let t1 = SystemTime::UNIX_EPOCH + Duration::from_secs(3);
+
+    assert_eq!(clock.now()?, t1);
+    assert_eq!(clock.now()?, t1);
 
     Ok(())
 }

--- a/envoy-sdk-test/tests/host/time.rs
+++ b/envoy-sdk-test/tests/host/time.rs
@@ -1,0 +1,60 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::{Duration, SystemTime};
+
+use envoy::host::{Clock, Result};
+
+use envoy_sdk_test as envoy_test;
+use envoy_test::FakeClock;
+
+#[test]
+fn test_fake_clock() -> Result<()> {
+    let clock = FakeClock::default();
+
+    assert_eq!(clock.now()?, SystemTime::UNIX_EPOCH);
+    assert_eq!(clock.now()?, SystemTime::UNIX_EPOCH);
+
+    Ok(())
+}
+
+#[test]
+fn test_fake_clock_at_given_time() -> Result<()> {
+    let clock = FakeClock::default();
+
+    let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(5);
+
+    clock.freeze_at(t0);
+
+    assert_eq!(clock.now()?, t0);
+    assert_eq!(clock.now()?, t0);
+
+    Ok(())
+}
+
+#[test]
+fn test_fake_clock_at_given_times() -> Result<()> {
+    let clock = FakeClock::default();
+
+    let t0 = SystemTime::UNIX_EPOCH;
+    let moments = (0..).map(move |i| t0 + Duration::from_secs(i));
+
+    clock.tick_at(moments);
+
+    assert_eq!(clock.now()?, t0);
+    assert_eq!(clock.now()?, t0 + Duration::from_secs(1));
+    assert_eq!(clock.now()?, t0 + Duration::from_secs(2));
+
+    Ok(())
+}

--- a/envoy-sdk-test/tests/mod.rs
+++ b/envoy-sdk-test/tests/mod.rs
@@ -12,8 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Fake `Envoy` `Host APIs` for use in unit tests.
-
-pub use self::time::FakeClock;
-
-pub mod time;
+mod host;

--- a/envoy-sdk/src/host/time.rs
+++ b/envoy-sdk/src/host/time.rs
@@ -18,7 +18,7 @@ use std::time::SystemTime;
 
 use crate::host;
 
-/// An interface of the `Envoy` `Time Service`.
+/// An interface of the `Envoy` `System Clock`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary

* introduce `unit test framework`
* add `FakeClock` API