### PR TITLE
envoy-sdk-test: add a separate Cargo crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "envoy-sdk",
+    "envoy-sdk-test",
     "examples/access-logger",
     "examples/access-logger/wasm/module",
     "examples/http-filter",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,27 @@ that brings in structure and guidance for extension developers.
 
 ```toml
 [dependencies]
-envoy-sdk = "0.1"
+envoy = { package = "envoy-sdk", version = "0.1" }
+```
+
+```rust
+use envoy::extension::{HttpFilter, Result};
+use envoy::extension::filter::http;
+use envoy::host::log;
+
+/// My very own `HttpFilter`.
+struct MyHttpFilter;
+
+impl HttpFilter for MyHttpFilter {
+
+  /// Called when HTTP request headers have been received.
+  ///
+  /// Use `_ops` to access or mutate request headers.
+  fn on_request_headers(&mut self, _num_headers: usize, _end_of_stream: bool, _ops: &dyn http::RequestHeadersOps) -> Result<http::FilterHeadersStatus> {
+    log::info!("proxying an HTTP request");
+    Ok(http::FilterHeadersStatus::Continue)
+  }
+}
 ```
 
 ## Components

--- a/envoy-sdk-test/Cargo.toml
+++ b/envoy-sdk-test/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "envoy-sdk-test"
+version = "0.0.1"
+authors = ["Tetrate Labs <tetratelabs@tetrate.io>"]
+description = "Rust SDK for WebAssembly-based Envoy extensions"
+license = "Apache-2.0"
+repository = "https://github.com/tetratelabs/envoy-wasm-rust-sdk/"
+readme = "README.md"
+keywords = ["envoy", "extension", "wasm"]
+categories = ["wasm"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+envoy = { path = "../envoy-sdk", package = "envoy-sdk" }
+
+[dev-dependencies]
+version-sync = "0.9"

--- a/envoy-sdk-test/README.md
+++ b/envoy-sdk-test/README.md
@@ -1,0 +1,1 @@
+# Rust SDK for WebAssembly-based Envoy extensions: Unit Test Framework

--- a/envoy-sdk-test/src/lib.rs
+++ b/envoy-sdk-test/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![doc(html_root_url = "https://docs.rs/envoy-sdk-test/0.0.1")]

--- a/envoy-sdk-test/tests/version-numbers.rs
+++ b/envoy-sdk-test/tests/version-numbers.rs
@@ -1,0 +1,23 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}

--- a/examples/access-logger/Cargo.toml
+++ b/examples/access-logger/Cargo.toml
@@ -15,3 +15,6 @@ envoy = { path = "../../envoy-sdk", package = "envoy-sdk" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
+
+[dev-dependencies]
+envoy-test = { path = "../../envoy-sdk-test", package = "envoy-sdk-test" }

--- a/examples/http-filter/Cargo.toml
+++ b/examples/http-filter/Cargo.toml
@@ -15,3 +15,6 @@ envoy = { path = "../../envoy-sdk", package = "envoy-sdk" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
+
+[dev-dependencies]
+envoy-test = { path = "../../envoy-sdk-test", package = "envoy-sdk-test" }

--- a/examples/network-filter/Cargo.toml
+++ b/examples/network-filter/Cargo.toml
@@ -15,3 +15,6 @@ envoy = { path = "../../envoy-sdk", package = "envoy-sdk" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4"
+
+[dev-dependencies]
+envoy-test = { path = "../../envoy-sdk-test", package = "envoy-sdk-test" }


### PR DESCRIPTION
## Summary

* introduce a separate Cargo crate for unit test framework

## Motivation

* avoid mixing documentation for main and test code
* leave a room for different release cycle