### PR TITLE
envoy-sdk-test: add `FakeStreamInfo` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@ impl HttpFilter for MyHttpFilter {
   * [http-filter](./examples/http-filter/) - logs HTTP request/response headers, makes an outgoing HTTP request
   * [network-filter](./examples/network-filter/) - logs start and end of a TCP conection, makes an outgoing HTTP request
   * [access-logger](./examples/access-logger/) - logs information about an HTTP request or a TCP connection, makes an outgoing HTTP request
+
+## Latest docs (on `master`)
+
+* [envoy-sdk](https://tetratelabs.github.io/envoy-wasm-rust-sdk/envoy_sdk/)
+* [envoy-sdk-test](https://tetratelabs.github.io/envoy-wasm-rust-sdk/envoy_sdk_test/)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ impl HttpFilter for MyHttpFilter {
 ## Components
 
 * [envoy-sdk](./envoy-sdk/) - `Envoy SDK`
+* [envoy-sdk-test](./envoy-sdk-test/) - `Unit Test Framework` accompanying `Envoy SDK`
 * [examples](./examples/) - `Envoy SDK` usage examples
   * [http-filter](./examples/http-filter/) - logs HTTP request/response headers, makes an outgoing HTTP request
   * [network-filter](./examples/network-filter/) - logs start and end of a TCP conection, makes an outgoing HTTP request

--- a/envoy-sdk-test/src/host/mod.rs
+++ b/envoy-sdk-test/src/host/mod.rs
@@ -16,10 +16,12 @@
 
 pub use self::http::client::{FakeHttpClient, FakeHttpClientRequest, FakeHttpClientResponse};
 pub use self::stats::FakeStats;
+pub use self::stream_info::FakeStreamInfo;
 pub use self::time::FakeClock;
 
 pub mod http;
 pub mod stats;
+pub mod stream_info;
 pub mod time;
 
 pub(crate) mod simulate;

--- a/envoy-sdk-test/src/host/stream_info.rs
+++ b/envoy-sdk-test/src/host/stream_info.rs
@@ -1,0 +1,1090 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Fake `Stream Info API`.
+
+use std::time::{Duration, SystemTime};
+
+use envoy::extension::access_logger;
+use envoy::host::stream_info::{ResponseFlags, StreamInfo, TrafficDirection};
+use envoy::host::{self, ByteString, HeaderMap};
+
+use crate::host::http::FakeHttpMessage;
+
+/// Represents fake `Stream Info`.
+#[derive(Debug, Default, Clone)]
+pub struct FakeStreamInfo {
+    connection: Option<FakeConnectionInfo>,
+    request: Option<FakeRequestInfo>,
+    response: Option<FakeResponseInfo>,
+    upstream: Option<FakeUpstreamInfo>,
+    source: Option<FakePeerInfo>,
+    destination: Option<FakePeerInfo>,
+    listener: Option<FakeListenerInfo>,
+    route: Option<FakeRouteInfo>,
+    cluster: Option<FakeClusterInfo>,
+    plugin: Option<FakePluginInfo>,
+}
+
+/// Represents `connection` info.
+#[derive(Debug, Default, Clone)]
+struct FakeConnectionInfo {
+    id: u64,
+    mtls: bool,
+    requested_server_name: String,
+    tls: Option<FakeTlsInfo>,
+}
+
+/// Represents `TLS` info.
+#[derive(Debug, Default, Clone)]
+struct FakeTlsInfo {
+    version: Option<String>,
+    subject_local_certificate: Option<String>,
+    subject_peer_certificate: Option<String>,
+    uri_san_local_certificate: Option<String>,
+    uri_san_peer_certificate: Option<String>,
+    dns_san_local_certificate: Option<String>,
+    dns_san_peer_certificate: Option<String>,
+}
+
+/// Represents `request` info.
+#[derive(Debug, Default, Clone)]
+struct FakeRequestInfo {
+    message: FakeHttpMessage,
+    protocol: Option<String>,
+    id: Option<String>,
+    time: Option<SystemTime>,
+    duration: Option<Duration>,
+    size: u64,
+    total_size: u64,
+}
+
+/// Represents `response` info.
+#[derive(Debug, Default, Clone)]
+struct FakeResponseInfo {
+    message: FakeHttpMessage,
+    size: u64,
+    total_size: u64,
+    flags: ResponseFlags,
+}
+
+/// Represents `upstream` info.
+#[derive(Debug, Default, Clone)]
+struct FakeUpstreamInfo {
+    address: String,
+    port: u32,
+    local_address: Option<String>,
+    transport_failure_reason: Option<String>,
+    tls: Option<FakeTlsInfo>,
+}
+
+/// Represents info about connection `source` or `destination`.
+#[derive(Debug, Default, Clone)]
+struct FakePeerInfo {
+    address: String,
+    port: u32,
+}
+
+/// Represents `listener` info.
+#[derive(Debug, Default, Clone)]
+struct FakeListenerInfo {
+    traffic_direction: TrafficDirection,
+}
+
+/// Represents `route` info.
+#[derive(Debug, Default, Clone)]
+struct FakeRouteInfo {
+    name: String,
+}
+
+/// Represents `cluster` info.
+#[derive(Debug, Default, Clone)]
+struct FakeClusterInfo {
+    name: String,
+}
+
+/// Represents `plugin` info.
+#[derive(Debug, Default, Clone)]
+struct FakePluginInfo {
+    name: String,
+    root_id: String,
+    vm_id: String,
+}
+
+pub struct FakeConnectionInfoBuilder<'a> {
+    connection: &'a mut Option<FakeConnectionInfo>,
+}
+
+pub struct FakeTlsInfoBuilder<'a> {
+    tls: &'a mut Option<FakeTlsInfo>,
+}
+
+pub struct FakeRequestInfoBuilder<'a> {
+    request: &'a mut Option<FakeRequestInfo>,
+}
+
+pub struct FakeResponseInfoBuilder<'a> {
+    response: &'a mut Option<FakeResponseInfo>,
+}
+
+pub struct FakeUpstreamInfoBuilder<'a> {
+    upstream: &'a mut Option<FakeUpstreamInfo>,
+}
+
+pub struct FakeSourceInfoBuilder<'a> {
+    source: &'a mut Option<FakePeerInfo>,
+}
+
+pub struct FakeDestinationInfoBuilder<'a> {
+    destination: &'a mut Option<FakePeerInfo>,
+}
+
+pub struct FakeListenerInfoBuilder<'a> {
+    listener: &'a mut Option<FakeListenerInfo>,
+}
+
+pub struct FakeRouteInfoBuilder<'a> {
+    route: &'a mut Option<FakeRouteInfo>,
+}
+
+pub struct FakeClusterInfoBuilder<'a> {
+    cluster: &'a mut Option<FakeClusterInfo>,
+}
+
+pub struct FakePluginInfoBuilder<'a> {
+    plugin: &'a mut Option<FakePluginInfo>,
+}
+
+impl FakeStreamInfo {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with(mut self, builder: impl FnOnce(&mut Self)) -> Self {
+        builder(&mut self);
+        self
+    }
+
+    pub fn connection(&mut self) -> FakeConnectionInfoBuilder<'_> {
+        FakeConnectionInfoBuilder {
+            connection: &mut self.connection,
+        }
+    }
+
+    pub fn request(&mut self) -> FakeRequestInfoBuilder<'_> {
+        FakeRequestInfoBuilder {
+            request: &mut self.request,
+        }
+    }
+
+    pub fn response(&mut self) -> FakeResponseInfoBuilder<'_> {
+        FakeResponseInfoBuilder {
+            response: &mut self.response,
+        }
+    }
+
+    pub fn upstream(&mut self) -> FakeUpstreamInfoBuilder<'_> {
+        FakeUpstreamInfoBuilder {
+            upstream: &mut self.upstream,
+        }
+    }
+
+    pub fn source(&mut self) -> FakeSourceInfoBuilder<'_> {
+        FakeSourceInfoBuilder {
+            source: &mut self.source,
+        }
+    }
+
+    pub fn destination(&mut self) -> FakeDestinationInfoBuilder<'_> {
+        FakeDestinationInfoBuilder {
+            destination: &mut self.destination,
+        }
+    }
+
+    pub fn listener(&mut self) -> FakeListenerInfoBuilder<'_> {
+        FakeListenerInfoBuilder {
+            listener: &mut self.listener,
+        }
+    }
+
+    pub fn route(&mut self) -> FakeRouteInfoBuilder<'_> {
+        FakeRouteInfoBuilder {
+            route: &mut self.route,
+        }
+    }
+
+    pub fn cluster(&mut self) -> FakeClusterInfoBuilder<'_> {
+        FakeClusterInfoBuilder {
+            cluster: &mut self.cluster,
+        }
+    }
+
+    pub fn plugin(&mut self) -> FakePluginInfoBuilder<'_> {
+        FakePluginInfoBuilder {
+            plugin: &mut self.plugin,
+        }
+    }
+}
+
+impl<'a> FakeConnectionInfoBuilder<'a> {
+    pub fn id(&mut self, value: u64) -> &mut Self {
+        self.connection.get_or_insert_with(Default::default).id = value;
+        self
+    }
+
+    pub fn mtls(&mut self, value: bool) -> &mut Self {
+        self.connection.get_or_insert_with(Default::default).mtls = value;
+        self
+    }
+
+    pub fn requested_server_name<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.connection
+            .get_or_insert_with(Default::default)
+            .requested_server_name = value.as_ref().to_owned();
+        self
+    }
+
+    pub fn tls(&mut self) -> FakeTlsInfoBuilder<'_> {
+        FakeTlsInfoBuilder {
+            tls: &mut self.connection.get_or_insert_with(Default::default).tls,
+        }
+    }
+}
+
+impl<'a> FakeTlsInfoBuilder<'a> {
+    pub fn version<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.tls.get_or_insert_with(Default::default).version = Some(value.as_ref().to_owned());
+        self
+    }
+
+    pub fn subject_local_certificate<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.tls
+            .get_or_insert_with(Default::default)
+            .subject_local_certificate = Some(value.as_ref().to_owned());
+        self
+    }
+
+    pub fn subject_peer_certificate<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.tls
+            .get_or_insert_with(Default::default)
+            .subject_peer_certificate = Some(value.as_ref().to_owned());
+        self
+    }
+
+    pub fn uri_san_local_certificate<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.tls
+            .get_or_insert_with(Default::default)
+            .uri_san_local_certificate = Some(value.as_ref().to_owned());
+        self
+    }
+
+    pub fn uri_san_peer_certificate<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.tls
+            .get_or_insert_with(Default::default)
+            .uri_san_peer_certificate = Some(value.as_ref().to_owned());
+        self
+    }
+
+    pub fn dns_san_local_certificate<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.tls
+            .get_or_insert_with(Default::default)
+            .dns_san_local_certificate = Some(value.as_ref().to_owned());
+        self
+    }
+
+    pub fn dns_san_peer_certificate<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.tls
+            .get_or_insert_with(Default::default)
+            .dns_san_peer_certificate = Some(value.as_ref().to_owned());
+        self
+    }
+}
+
+impl<'a> FakeRequestInfoBuilder<'a> {
+    pub fn header<K, V>(&mut self, name: K, value: V) -> &mut Self
+    where
+        K: Into<ByteString>,
+        V: Into<ByteString>,
+    {
+        self.request
+            .get_or_insert_with(Default::default)
+            .message
+            .headers
+            .insert(name, value);
+        self
+    }
+
+    pub fn method<V>(&mut self, value: V) -> &mut Self
+    where
+        V: AsRef<str>,
+    {
+        self.request
+            .get_or_insert_with(Default::default)
+            .message
+            .headers
+            .insert(":method", value.as_ref());
+        self
+    }
+
+    pub fn scheme<V>(&mut self, value: V) -> &mut Self
+    where
+        V: AsRef<str>,
+    {
+        self.request
+            .get_or_insert_with(Default::default)
+            .message
+            .headers
+            .insert(":scheme", value.as_ref());
+        self
+    }
+
+    pub fn host<V>(&mut self, value: V) -> &mut Self
+    where
+        V: AsRef<str>,
+    {
+        self.request
+            .get_or_insert_with(Default::default)
+            .message
+            .headers
+            .insert(":authority", value.as_ref());
+        self
+    }
+
+    pub fn path<V>(&mut self, value: V) -> &mut Self
+    where
+        V: AsRef<str>,
+    {
+        self.request
+            .get_or_insert_with(Default::default)
+            .message
+            .headers
+            .insert(":path", value.as_ref());
+        self
+    }
+
+    pub fn protocol<V>(&mut self, value: V) -> &mut Self
+    where
+        V: AsRef<str>,
+    {
+        self.request.get_or_insert_with(Default::default).protocol = Some(value.as_ref().into());
+        self
+    }
+
+    pub fn id<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.request.get_or_insert_with(Default::default).id = Some(value.as_ref().into());
+        self
+    }
+
+    pub fn time(&mut self, value: SystemTime) -> &mut Self {
+        self.request.get_or_insert_with(Default::default).time = Some(value);
+        self
+    }
+
+    pub fn duration(&mut self, value: Duration) -> &mut Self {
+        self.request.get_or_insert_with(Default::default).duration = Some(value);
+        self
+    }
+
+    pub fn size(&mut self, value: u64) -> &mut Self {
+        self.request.get_or_insert_with(Default::default).size = value;
+        self
+    }
+
+    pub fn total_size(&mut self, value: u64) -> &mut Self {
+        self.request.get_or_insert_with(Default::default).total_size = value;
+        self
+    }
+}
+
+impl<'a> FakeResponseInfoBuilder<'a> {
+    pub fn status_code(&mut self, value: u16) -> &mut Self {
+        self.response
+            .get_or_insert_with(Default::default)
+            .message
+            .headers
+            .insert(":status", value.to_string());
+        self
+    }
+
+    pub fn header<K, V>(&mut self, name: K, value: V) -> &mut Self
+    where
+        K: Into<ByteString>,
+        V: Into<ByteString>,
+    {
+        self.response
+            .get_or_insert_with(Default::default)
+            .message
+            .headers
+            .insert(name.into(), value.into());
+        self
+    }
+
+    pub fn trailer<K, V>(&mut self, name: K, value: V) -> &mut Self
+    where
+        K: Into<ByteString>,
+        V: Into<ByteString>,
+    {
+        self.response
+            .get_or_insert_with(Default::default)
+            .message
+            .trailers
+            .insert(name.into(), value.into());
+        self
+    }
+
+    pub fn size(&mut self, value: u64) -> &mut Self {
+        self.response.get_or_insert_with(Default::default).size = value;
+        self
+    }
+
+    pub fn total_size(&mut self, value: u64) -> &mut Self {
+        self.response
+            .get_or_insert_with(Default::default)
+            .total_size = value;
+        self
+    }
+
+    pub fn response_flags(&mut self, value: ResponseFlags) -> &mut Self {
+        self.response.get_or_insert_with(Default::default).flags = value;
+        self
+    }
+
+    pub fn grpc_status(&mut self, value: i32) -> &mut Self {
+        self.response
+            .get_or_insert_with(Default::default)
+            .message
+            .trailers
+            .insert("grpc-status", value.to_string());
+        self
+    }
+}
+
+impl FakeRequestInfo {
+    fn url_path(&self) -> host::Result<Option<String>> {
+        if let Some(path) = self.message.headers.get(":path") {
+            let path = path.clone().into_string()?;
+            let path: Vec<&str> = path.splitn(2, '?').collect();
+            Ok(path[0].to_owned()).map(Option::from)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl FakeResponseInfo {
+    fn status_code(&self) -> host::Result<Option<u16>> {
+        if let Some(status) = self.message.headers.get(":status") {
+            let status = status.clone().into_string()?;
+            Ok(status.parse::<u16>()?).map(Option::from)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn grpc_status(&self) -> host::Result<Option<i32>> {
+        if let Some(status) = self.message.trailers.get("grpc-status") {
+            let status = status.clone().into_string()?;
+            Ok(status.parse::<i32>()?).map(Option::from)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl<'a> FakeUpstreamInfoBuilder<'a> {
+    pub fn address<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.upstream.get_or_insert_with(Default::default).address = value.as_ref().to_owned();
+        self
+    }
+
+    pub fn port(&mut self, value: u32) -> &mut Self {
+        self.upstream.get_or_insert_with(Default::default).port = value;
+        self
+    }
+
+    pub fn local_address<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.upstream
+            .get_or_insert_with(Default::default)
+            .local_address = Some(value.as_ref().to_owned());
+        self
+    }
+
+    pub fn transport_failure_reason<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.upstream
+            .get_or_insert_with(Default::default)
+            .transport_failure_reason = Some(value.as_ref().to_owned());
+        self
+    }
+
+    pub fn tls(&mut self) -> FakeTlsInfoBuilder<'_> {
+        FakeTlsInfoBuilder {
+            tls: &mut self.upstream.get_or_insert_with(Default::default).tls,
+        }
+    }
+}
+
+impl<'a> FakeSourceInfoBuilder<'a> {
+    pub fn address<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.source.get_or_insert_with(Default::default).address = value.as_ref().to_owned();
+        self
+    }
+
+    pub fn port(&mut self, value: u32) -> &mut Self {
+        self.source.get_or_insert_with(Default::default).port = value;
+        self
+    }
+}
+
+impl<'a> FakeDestinationInfoBuilder<'a> {
+    pub fn address<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.destination
+            .get_or_insert_with(Default::default)
+            .address = value.as_ref().to_owned();
+        self
+    }
+
+    pub fn port(&mut self, value: u32) -> &mut Self {
+        self.destination.get_or_insert_with(Default::default).port = value;
+        self
+    }
+}
+
+impl<'a> FakeListenerInfoBuilder<'a> {
+    pub fn traffic_direction(&mut self, value: TrafficDirection) -> &mut Self {
+        self.listener
+            .get_or_insert_with(Default::default)
+            .traffic_direction = value;
+        self
+    }
+}
+
+impl<'a> FakeRouteInfoBuilder<'a> {
+    pub fn name<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.route.get_or_insert_with(Default::default).name = value.as_ref().to_owned();
+        self
+    }
+}
+
+impl<'a> FakeClusterInfoBuilder<'a> {
+    pub fn name<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.cluster.get_or_insert_with(Default::default).name = value.as_ref().to_owned();
+        self
+    }
+}
+
+impl<'a> FakePluginInfoBuilder<'a> {
+    pub fn name<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.plugin.get_or_insert_with(Default::default).name = value.as_ref().to_owned();
+        self
+    }
+
+    pub fn root_id<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.plugin.get_or_insert_with(Default::default).root_id = value.as_ref().to_owned();
+        self
+    }
+
+    pub fn vm_id<T>(&mut self, value: T) -> &mut Self
+    where
+        T: AsRef<str>,
+    {
+        self.plugin.get_or_insert_with(Default::default).vm_id = value.as_ref().to_owned();
+        self
+    }
+}
+
+impl StreamInfo for FakeStreamInfo {
+    fn stream_property(&self, path: &[&str]) -> host::Result<Option<ByteString>> {
+        let encoded = match path {
+            // connection
+            ["connection_id"] => self
+                .connection
+                .as_ref()
+                .map(|con| con.id)
+                .map(Encoder::encode_u64),
+            ["connection", "mtls"] => self
+                .connection
+                .as_ref()
+                .map(|con| con.mtls)
+                .map(Encoder::encode_bool),
+            ["connection", "requested_server_name"] => self
+                .connection
+                .as_ref()
+                .map(|con| &con.requested_server_name)
+                .map(Encoder::encode_str),
+            ["connection", "tls_version"] => self
+                .connection
+                .as_ref()
+                .map(|con| con.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.version.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["connection", "subject_local_certificate"] => self
+                .connection
+                .as_ref()
+                .map(|con| con.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.subject_local_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["connection", "subject_peer_certificate"] => self
+                .connection
+                .as_ref()
+                .map(|con| con.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.subject_peer_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["connection", "uri_san_local_certificate"] => self
+                .connection
+                .as_ref()
+                .map(|con| con.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.uri_san_local_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["connection", "uri_san_peer_certificate"] => self
+                .connection
+                .as_ref()
+                .map(|con| con.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.uri_san_peer_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["connection", "dns_san_local_certificate"] => self
+                .connection
+                .as_ref()
+                .map(|con| con.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.dns_san_local_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["connection", "dns_san_peer_certificate"] => self
+                .connection
+                .as_ref()
+                .map(|con| con.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.dns_san_peer_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            // request
+            ["request", "headers", name] => self
+                .request
+                .as_ref()
+                .map(|request| request.message.headers.get(name))
+                .flatten()
+                .map(Encoder::encode_str),
+            ["request", "id"] => self
+                .request
+                .as_ref()
+                .map(|request| request.id.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["request", "time"] => self
+                .request
+                .as_ref()
+                .map(|request| request.time)
+                .flatten()
+                .map(Encoder::encode_timestamp),
+            ["request", "duration"] => self
+                .request
+                .as_ref()
+                .map(|request| request.duration)
+                .flatten()
+                .map(Encoder::encode_duration),
+            ["request", "size"] => self
+                .request
+                .as_ref()
+                .map(|request| request.size as i64)
+                .map(Encoder::encode_i64),
+            ["request", "total_size"] => self
+                .request
+                .as_ref()
+                .map(|request| request.total_size as i64)
+                .map(Encoder::encode_i64),
+            ["request", "method"] => self
+                .request
+                .as_ref()
+                .map(|request| request.message.headers.get(":method"))
+                .flatten()
+                .map(Encoder::encode_str),
+            ["request", "scheme"] => self
+                .request
+                .as_ref()
+                .map(|request| request.message.headers.get(":scheme"))
+                .flatten()
+                .map(Encoder::encode_str),
+            ["request", "host"] => self
+                .request
+                .as_ref()
+                .map(|request| request.message.headers.get(":authority"))
+                .flatten()
+                .map(Encoder::encode_str),
+            ["request", "path"] => self
+                .request
+                .as_ref()
+                .map(|request| request.message.headers.get(":path"))
+                .flatten()
+                .map(Encoder::encode_str),
+            ["request", "url_path"] => self
+                .request
+                .as_ref()
+                .map(|request| request.url_path())
+                .transpose()?
+                .flatten()
+                .map(Encoder::encode_str),
+            ["request", "protocol"] => self
+                .request
+                .as_ref()
+                .map(|request| request.protocol.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["request", "useragent"] => self
+                .request
+                .as_ref()
+                .map(|request| request.message.headers.get("user-agent"))
+                .flatten()
+                .map(Encoder::encode_str),
+            ["request", "referer"] => self
+                .request
+                .as_ref()
+                .map(|request| request.message.headers.get("referer"))
+                .flatten()
+                .map(Encoder::encode_str),
+            // response
+            ["response", "headers", name] => self
+                .response
+                .as_ref()
+                .map(|response| response.message.headers.get(name))
+                .flatten()
+                .map(Encoder::encode_str),
+            ["response", "trailers", name] => self
+                .response
+                .as_ref()
+                .map(|response| response.message.trailers.get(name))
+                .flatten()
+                .map(Encoder::encode_str),
+            ["response", "code"] => self
+                .response
+                .as_ref()
+                .map(|response| response.status_code())
+                .transpose()?
+                .flatten()
+                .map(|status_code| status_code as i64)
+                .map(Encoder::encode_i64),
+            ["response", "size"] => self
+                .response
+                .as_ref()
+                .map(|response| response.size as i64)
+                .map(Encoder::encode_i64),
+            ["response", "total_size"] => self
+                .response
+                .as_ref()
+                .map(|response| response.total_size as i64)
+                .map(Encoder::encode_i64),
+            ["response", "flags"] => self
+                .response
+                .as_ref()
+                .map(|response| response.flags.bits() as i64)
+                .map(Encoder::encode_i64),
+            ["response", "grpc_status"] => self
+                .response
+                .as_ref()
+                .map(|response| response.grpc_status())
+                .transpose()?
+                .flatten()
+                .map(|status_code| status_code as i64)
+                .map(Encoder::encode_i64),
+            // upstream
+            ["upstream", "address"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| &upstream.address)
+                .map(Encoder::encode_str),
+            ["upstream", "port"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.port as i64)
+                .map(Encoder::encode_i64),
+            ["upstream", "local_address"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.local_address.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["upstream", "transport_failure_reason"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.transport_failure_reason.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["upstream", "tls_version"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.version.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["upstream", "subject_local_certificate"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.subject_local_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["upstream", "subject_peer_certificate"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.subject_peer_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["upstream", "uri_san_local_certificate"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.uri_san_local_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["upstream", "uri_san_peer_certificate"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.uri_san_peer_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["upstream", "dns_san_local_certificate"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.dns_san_local_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            ["upstream", "dns_san_peer_certificate"] => self
+                .upstream
+                .as_ref()
+                .map(|upstream| upstream.tls.as_ref())
+                .flatten()
+                .map(|tls| tls.dns_san_peer_certificate.as_ref())
+                .flatten()
+                .map(Encoder::encode_str),
+            // source
+            ["source", "address"] => self
+                .source
+                .as_ref()
+                .map(|source| &source.address)
+                .map(Encoder::encode_str),
+            ["source", "port"] => self
+                .source
+                .as_ref()
+                .map(|source| source.port as i64)
+                .map(Encoder::encode_i64),
+            // destination
+            ["destination", "address"] => self
+                .destination
+                .as_ref()
+                .map(|destination| &destination.address)
+                .map(Encoder::encode_str),
+            ["destination", "port"] => self
+                .destination
+                .as_ref()
+                .map(|destination| destination.port as i64)
+                .map(Encoder::encode_i64),
+            // listener
+            ["listener_direction"] => self
+                .listener
+                .as_ref()
+                .map(|listener| listener.traffic_direction as i64)
+                .map(Encoder::encode_i64),
+            // route
+            ["route_name"] => self
+                .route
+                .as_ref()
+                .map(|route| &route.name)
+                .map(Encoder::encode_str),
+            // cluster
+            ["cluster_name"] => self
+                .cluster
+                .as_ref()
+                .map(|cluster| &cluster.name)
+                .map(Encoder::encode_str),
+            // plugin
+            ["plugin_name"] => self
+                .plugin
+                .as_ref()
+                .map(|plugin| &plugin.name)
+                .map(Encoder::encode_str),
+            ["plugin_root_id"] => self
+                .plugin
+                .as_ref()
+                .map(|plugin| &plugin.root_id)
+                .map(Encoder::encode_str),
+            ["plugin_vm_id"] => self
+                .plugin
+                .as_ref()
+                .map(|plugin| &plugin.vm_id)
+                .map(Encoder::encode_str),
+            _ => None,
+        };
+        encoded.unwrap_or_else(|| Ok(None))
+    }
+
+    fn set_stream_property(&self, _path: &[&str], _value: &[u8]) -> host::Result<()> {
+        Ok(())
+    }
+}
+
+impl access_logger::LogOps for FakeStreamInfo {
+    fn request_headers(&self) -> host::Result<HeaderMap> {
+        Ok(self
+            .request
+            .as_ref()
+            .map(|request| request.message.headers.clone())
+            .unwrap_or_else(Default::default))
+    }
+
+    fn request_header(&self, name: &str) -> host::Result<Option<ByteString>> {
+        Ok(self
+            .request
+            .as_ref()
+            .map(|request| request.message.headers.get(name).map(Clone::clone))
+            .flatten())
+    }
+
+    fn response_headers(&self) -> host::Result<HeaderMap> {
+        Ok(self
+            .response
+            .as_ref()
+            .map(|response| response.message.headers.clone())
+            .unwrap_or_else(Default::default))
+    }
+
+    fn response_header(&self, name: &str) -> host::Result<Option<ByteString>> {
+        Ok(self
+            .response
+            .as_ref()
+            .map(|response| response.message.headers.get(name).map(Clone::clone))
+            .flatten())
+    }
+
+    fn response_trailers(&self) -> host::Result<HeaderMap> {
+        Ok(self
+            .response
+            .as_ref()
+            .map(|response| response.message.trailers.clone())
+            .unwrap_or_else(Default::default))
+    }
+
+    fn response_trailer(&self, name: &str) -> host::Result<Option<ByteString>> {
+        Ok(self
+            .response
+            .as_ref()
+            .map(|response| response.message.trailers.get(name).map(Clone::clone))
+            .flatten())
+    }
+
+    fn stream_info(&self) -> &dyn StreamInfo {
+        self
+    }
+}
+
+struct Encoder;
+
+impl Encoder {
+    pub fn encode_i64(value: i64) -> host::Result<Option<ByteString>> {
+        Ok(Some(value.to_le_bytes().as_ref().into()))
+    }
+
+    pub fn encode_u64(value: u64) -> host::Result<Option<ByteString>> {
+        Ok(Some(value.to_le_bytes().as_ref().into()))
+    }
+
+    pub fn encode_bool(value: bool) -> host::Result<Option<ByteString>> {
+        Ok(Some((value as u8).to_le_bytes().as_ref().into()))
+    }
+
+    pub fn encode_str<T: AsRef<[u8]>>(value: T) -> host::Result<Option<ByteString>> {
+        Ok(Some(value.as_ref().into()))
+    }
+
+    pub fn encode_timestamp(value: SystemTime) -> host::Result<Option<ByteString>> {
+        let value = value.duration_since(SystemTime::UNIX_EPOCH)?;
+        Self::encode_duration(value)
+    }
+
+    pub fn encode_duration(value: Duration) -> host::Result<Option<ByteString>> {
+        let value = value.as_secs() * 1_000_000_000 + value.subsec_nanos() as u64;
+        Self::encode_i64(value as i64)
+    }
+}

--- a/envoy-sdk-test/src/host/stream_info.rs
+++ b/envoy-sdk-test/src/host/stream_info.rs
@@ -1025,7 +1025,7 @@ impl access_logger::LogOps for FakeStreamInfo {
             .request
             .as_ref()
             .map(|request| request.message.headers.clone())
-            .unwrap_or_else(Default::default))
+            .unwrap_or_default())
     }
 
     fn request_header(&self, name: &str) -> host::Result<Option<ByteString>> {
@@ -1041,7 +1041,7 @@ impl access_logger::LogOps for FakeStreamInfo {
             .response
             .as_ref()
             .map(|response| response.message.headers.clone())
-            .unwrap_or_else(Default::default))
+            .unwrap_or_default())
     }
 
     fn response_header(&self, name: &str) -> host::Result<Option<ByteString>> {
@@ -1057,7 +1057,7 @@ impl access_logger::LogOps for FakeStreamInfo {
             .response
             .as_ref()
             .map(|response| response.message.trailers.clone())
-            .unwrap_or_else(Default::default))
+            .unwrap_or_default())
     }
 
     fn response_trailer(&self, name: &str) -> host::Result<Option<ByteString>> {

--- a/envoy-sdk-test/src/host/stream_info.rs
+++ b/envoy-sdk-test/src/host/stream_info.rs
@@ -13,6 +13,55 @@
 // limitations under the License.
 
 //! Fake `Stream Info API`.
+//!
+//! # Examples
+//!
+//! #### Basic usage of [`FakeStreamInfo`]:
+//!
+//! ```
+//! # use envoy_sdk_test as envoy_test;
+//! use envoy::host::StreamInfo;
+//! use envoy_test::FakeStreamInfo;
+//!
+//! # fn main() -> envoy::host::Result<()> {
+//! let fake_info = FakeStreamInfo::new().with(|info| {
+//!     info.connection()
+//!         .id(123)
+//!         .requested_server_name("example.org")
+//!         .tls()
+//!         .version("TLSv1.2")
+//!         .uri_san_local_certificate("spiffe://cluster.local/gateway");
+//!     info.request()
+//!         .id("a-b-c-d")
+//!         .size(1024)
+//!         .total_size(2048)
+//!         .method("GET")
+//!         .scheme("https")
+//!         .host("www.example.com")
+//!         .path("/search?q=example")
+//!         .protocol("HTTP/1.1")
+//!         .header("content-type", "application/json");
+//! });
+//! let stream_info: &dyn StreamInfo = &fake_info;
+//!
+//! assert_eq!(
+//!     stream_info.connection().requested_server_name()?,
+//!     Some("example.org".to_owned())
+//! );
+//! assert_eq!(
+//!     stream_info.request().path()?,
+//!     Some("/search?q=example".into())
+//! );
+//! assert_eq!(
+//!     stream_info.request().url_path()?,
+//!     Some("/search".into())
+//! );
+//!
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 
 use std::time::{Duration, SystemTime};
 
@@ -121,114 +170,182 @@ struct FakePluginInfo {
     vm_id: String,
 }
 
+/// Builder for `connection` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeConnectionInfoBuilder<'a> {
     connection: &'a mut Option<FakeConnectionInfo>,
 }
 
+/// Builder for `tls` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeTlsInfoBuilder<'a> {
     tls: &'a mut Option<FakeTlsInfo>,
 }
 
+/// Builder for `request` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeRequestInfoBuilder<'a> {
     request: &'a mut Option<FakeRequestInfo>,
 }
 
+/// Builder for `response` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeResponseInfoBuilder<'a> {
     response: &'a mut Option<FakeResponseInfo>,
 }
 
+/// Builder for `upstream` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeUpstreamInfoBuilder<'a> {
     upstream: &'a mut Option<FakeUpstreamInfo>,
 }
 
+/// Builder for `source` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeSourceInfoBuilder<'a> {
     source: &'a mut Option<FakePeerInfo>,
 }
 
+/// Builder for `destination` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeDestinationInfoBuilder<'a> {
     destination: &'a mut Option<FakePeerInfo>,
 }
 
+/// Builder for `listener` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeListenerInfoBuilder<'a> {
     listener: &'a mut Option<FakeListenerInfo>,
 }
 
+/// Builder for `route` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeRouteInfoBuilder<'a> {
     route: &'a mut Option<FakeRouteInfo>,
 }
 
+/// Builder for `cluster` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakeClusterInfoBuilder<'a> {
     cluster: &'a mut Option<FakeClusterInfo>,
 }
 
+/// Builder for `plugin` properties within [`FakeStreamInfo`].
+///
+/// [`FakeStreamInfo`]: struct.FakeStreamInfo.html
 pub struct FakePluginInfoBuilder<'a> {
     plugin: &'a mut Option<FakePluginInfo>,
 }
 
 impl FakeStreamInfo {
+    /// Returns a new instance.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Sets values of stream properties using a given callback.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use envoy_sdk_test as envoy_test;
+    /// use envoy_test::FakeStreamInfo;
+    ///
+    /// # fn main() -> envoy::host::Result<()> {
+    /// let fake_info = FakeStreamInfo::new().with(|info| {
+    ///     info.connection()
+    ///         .id(123)
+    ///         .requested_server_name("example.org");
+    ///     info.request()
+    ///         .method("GET")
+    ///         .scheme("https")
+    ///         .host("www.example.com")
+    ///         .path("/search?q=example")
+    ///         .protocol("HTTP/1.1")
+    ///         .header("content-type", "application/json");
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn with(mut self, builder: impl FnOnce(&mut Self)) -> Self {
         builder(&mut self);
         self
     }
 
+    /// Returns a builder for `connection` properties.
     pub fn connection(&mut self) -> FakeConnectionInfoBuilder<'_> {
         FakeConnectionInfoBuilder {
             connection: &mut self.connection,
         }
     }
 
+    /// Returns a builder for `request` properties.
     pub fn request(&mut self) -> FakeRequestInfoBuilder<'_> {
         FakeRequestInfoBuilder {
             request: &mut self.request,
         }
     }
 
+    /// Returns a builder for `response` properties.
     pub fn response(&mut self) -> FakeResponseInfoBuilder<'_> {
         FakeResponseInfoBuilder {
             response: &mut self.response,
         }
     }
 
+    /// Returns a builder for `upstream` properties.
     pub fn upstream(&mut self) -> FakeUpstreamInfoBuilder<'_> {
         FakeUpstreamInfoBuilder {
             upstream: &mut self.upstream,
         }
     }
 
+    /// Returns a builder for `source` properties.
     pub fn source(&mut self) -> FakeSourceInfoBuilder<'_> {
         FakeSourceInfoBuilder {
             source: &mut self.source,
         }
     }
 
+    /// Returns a builder for `destination` properties.
     pub fn destination(&mut self) -> FakeDestinationInfoBuilder<'_> {
         FakeDestinationInfoBuilder {
             destination: &mut self.destination,
         }
     }
 
+    /// Returns a builder for `listener` properties.
     pub fn listener(&mut self) -> FakeListenerInfoBuilder<'_> {
         FakeListenerInfoBuilder {
             listener: &mut self.listener,
         }
     }
 
+    /// Returns a builder for `route` properties.
     pub fn route(&mut self) -> FakeRouteInfoBuilder<'_> {
         FakeRouteInfoBuilder {
             route: &mut self.route,
         }
     }
 
+    /// Returns a builder for `cluster` properties.
     pub fn cluster(&mut self) -> FakeClusterInfoBuilder<'_> {
         FakeClusterInfoBuilder {
             cluster: &mut self.cluster,
         }
     }
 
+    /// Returns a builder for `plugin` properties.
     pub fn plugin(&mut self) -> FakePluginInfoBuilder<'_> {
         FakePluginInfoBuilder {
             plugin: &mut self.plugin,
@@ -237,24 +354,28 @@ impl FakeStreamInfo {
 }
 
 impl FakeTlsInfo {
+    /// Returns `true` if one of local certificate properties has been set.
     fn has_local_cert(&self) -> bool {
         self.subject_local_certificate.is_some()
             || self.uri_san_local_certificate.is_some()
             || self.dns_san_local_certificate.is_some()
     }
 
+    /// Returns `true` if one of peer certificate properties has been set.
     fn has_peer_cert(&self) -> bool {
         self.subject_peer_certificate.is_some()
             || self.uri_san_peer_certificate.is_some()
             || self.dns_san_peer_certificate.is_some()
     }
 
+    /// Returns `true` if both local and peer certificate properties have been set.
     fn is_mtls(&self) -> bool {
         self.has_local_cert() && self.has_peer_cert()
     }
 }
 
 impl FakeRequestInfo {
+    /// Returns the value of `:path` pseudo-header without a query component.
     fn url_path(&self) -> host::Result<Option<String>> {
         if let Some(path) = self.message.headers.get(":path") {
             let path = path.clone().into_string()?;
@@ -267,6 +388,7 @@ impl FakeRequestInfo {
 }
 
 impl FakeResponseInfo {
+    /// Returns the value of `:status` pseudo-header.
     fn status_code(&self) -> host::Result<Option<u16>> {
         if let Some(status) = self.message.headers.get(":status") {
             let status = status.clone().into_string()?;
@@ -276,6 +398,7 @@ impl FakeResponseInfo {
         }
     }
 
+    /// Returns the value of `grpc-status` trailer.
     fn grpc_status(&self) -> host::Result<Option<i32>> {
         if let Some(status) = self.message.trailers.get("grpc-status") {
             let status = status.clone().into_string()?;
@@ -287,11 +410,13 @@ impl FakeResponseInfo {
 }
 
 impl<'a> FakeConnectionInfoBuilder<'a> {
+    /// Sets the value of connection `id` property.
     pub fn id(&mut self, value: u64) -> &mut Self {
         self.connection.get_or_insert_with(Default::default).id = value;
         self
     }
 
+    /// Sets the value of connection `requested_server_name` property.
     pub fn requested_server_name<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -302,6 +427,7 @@ impl<'a> FakeConnectionInfoBuilder<'a> {
         self
     }
 
+    /// Returns a builder for `tls` properties of the downstream connection.
     pub fn tls(&mut self) -> FakeTlsInfoBuilder<'_> {
         FakeTlsInfoBuilder {
             tls: &mut self.connection.get_or_insert_with(Default::default).tls,
@@ -310,6 +436,7 @@ impl<'a> FakeConnectionInfoBuilder<'a> {
 }
 
 impl<'a> FakeTlsInfoBuilder<'a> {
+    /// Sets the value of `tls version` property.
     pub fn version<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -318,6 +445,7 @@ impl<'a> FakeTlsInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `subject_local_certificate` property.
     pub fn subject_local_certificate<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -328,6 +456,7 @@ impl<'a> FakeTlsInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `subject_peer_certificate` property.
     pub fn subject_peer_certificate<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -338,6 +467,7 @@ impl<'a> FakeTlsInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `uri_san_local_certificate` property.
     pub fn uri_san_local_certificate<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -348,6 +478,7 @@ impl<'a> FakeTlsInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `uri_san_peer_certificate` property.
     pub fn uri_san_peer_certificate<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -358,6 +489,7 @@ impl<'a> FakeTlsInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `dns_san_local_certificate` property.
     pub fn dns_san_local_certificate<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -368,6 +500,7 @@ impl<'a> FakeTlsInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `dns_san_peer_certificate` property.
     pub fn dns_san_peer_certificate<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -380,6 +513,7 @@ impl<'a> FakeTlsInfoBuilder<'a> {
 }
 
 impl<'a> FakeRequestInfoBuilder<'a> {
+    /// Sets the value of an HTTP request header.
     pub fn header<K, V>(&mut self, name: K, value: V) -> &mut Self
     where
         K: Into<ByteString>,
@@ -393,6 +527,7 @@ impl<'a> FakeRequestInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `:method` pseudo-header.
     pub fn method<V>(&mut self, value: V) -> &mut Self
     where
         V: AsRef<str>,
@@ -405,6 +540,7 @@ impl<'a> FakeRequestInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `:scheme` pseudo-header.
     pub fn scheme<V>(&mut self, value: V) -> &mut Self
     where
         V: AsRef<str>,
@@ -417,6 +553,7 @@ impl<'a> FakeRequestInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `:authority` pseudo-header.
     pub fn host<V>(&mut self, value: V) -> &mut Self
     where
         V: AsRef<str>,
@@ -429,6 +566,7 @@ impl<'a> FakeRequestInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of `:path` pseudo-header.
     pub fn path<V>(&mut self, value: V) -> &mut Self
     where
         V: AsRef<str>,
@@ -441,6 +579,7 @@ impl<'a> FakeRequestInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of request `protocol` property.
     pub fn protocol<V>(&mut self, value: V) -> &mut Self
     where
         V: AsRef<str>,
@@ -449,6 +588,7 @@ impl<'a> FakeRequestInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of request `id` property.
     pub fn id<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -457,21 +597,25 @@ impl<'a> FakeRequestInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of request `time` property.
     pub fn time(&mut self, value: SystemTime) -> &mut Self {
         self.request.get_or_insert_with(Default::default).time = Some(value);
         self
     }
 
+    /// Sets the value of request `duration` property.
     pub fn duration(&mut self, value: Duration) -> &mut Self {
         self.request.get_or_insert_with(Default::default).duration = Some(value);
         self
     }
 
+    /// Sets the value of request `size` property.
     pub fn size(&mut self, value: u64) -> &mut Self {
         self.request.get_or_insert_with(Default::default).size = value;
         self
     }
 
+    /// Sets the value of request `total_size` property.
     pub fn total_size(&mut self, value: u64) -> &mut Self {
         self.request.get_or_insert_with(Default::default).total_size = value;
         self
@@ -479,6 +623,7 @@ impl<'a> FakeRequestInfoBuilder<'a> {
 }
 
 impl<'a> FakeResponseInfoBuilder<'a> {
+    /// Returns the value of `:status` pseudo-header.
     pub fn status_code(&mut self, value: u16) -> &mut Self {
         self.response
             .get_or_insert_with(Default::default)
@@ -488,6 +633,7 @@ impl<'a> FakeResponseInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of an HTTP response header.
     pub fn header<K, V>(&mut self, name: K, value: V) -> &mut Self
     where
         K: Into<ByteString>,
@@ -501,6 +647,7 @@ impl<'a> FakeResponseInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of an HTTP response trailer.
     pub fn trailer<K, V>(&mut self, name: K, value: V) -> &mut Self
     where
         K: Into<ByteString>,
@@ -514,11 +661,13 @@ impl<'a> FakeResponseInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of request `size` property.
     pub fn size(&mut self, value: u64) -> &mut Self {
         self.response.get_or_insert_with(Default::default).size = value;
         self
     }
 
+    /// Sets the value of request `total_size` property.
     pub fn total_size(&mut self, value: u64) -> &mut Self {
         self.response
             .get_or_insert_with(Default::default)
@@ -526,11 +675,13 @@ impl<'a> FakeResponseInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of request `response_flags` property.
     pub fn response_flags(&mut self, value: ResponseFlags) -> &mut Self {
         self.response.get_or_insert_with(Default::default).flags = value;
         self
     }
 
+    /// Sets the value of `grpc-status` trailer.
     pub fn grpc_status(&mut self, value: i32) -> &mut Self {
         self.response
             .get_or_insert_with(Default::default)
@@ -542,6 +693,7 @@ impl<'a> FakeResponseInfoBuilder<'a> {
 }
 
 impl<'a> FakeUpstreamInfoBuilder<'a> {
+    /// Sets the value of upstream `address` property.
     pub fn address<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -550,11 +702,13 @@ impl<'a> FakeUpstreamInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of upstream `port` property.
     pub fn port(&mut self, value: u32) -> &mut Self {
         self.upstream.get_or_insert_with(Default::default).port = value;
         self
     }
 
+    /// Sets the value of upstream `local_address` property.
     pub fn local_address<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -565,6 +719,7 @@ impl<'a> FakeUpstreamInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of upstream `transport_failure_reason` property.
     pub fn transport_failure_reason<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -575,6 +730,7 @@ impl<'a> FakeUpstreamInfoBuilder<'a> {
         self
     }
 
+    /// Returns a builder for `tls` properties of the upstream connection.
     pub fn tls(&mut self) -> FakeTlsInfoBuilder<'_> {
         FakeTlsInfoBuilder {
             tls: &mut self.upstream.get_or_insert_with(Default::default).tls,
@@ -583,6 +739,7 @@ impl<'a> FakeUpstreamInfoBuilder<'a> {
 }
 
 impl<'a> FakeSourceInfoBuilder<'a> {
+    /// Sets the value of source `address` property.
     pub fn address<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -591,6 +748,7 @@ impl<'a> FakeSourceInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of source `port` property.
     pub fn port(&mut self, value: u32) -> &mut Self {
         self.source.get_or_insert_with(Default::default).port = value;
         self
@@ -598,6 +756,7 @@ impl<'a> FakeSourceInfoBuilder<'a> {
 }
 
 impl<'a> FakeDestinationInfoBuilder<'a> {
+    /// Sets the value of destination `address` property.
     pub fn address<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -608,6 +767,7 @@ impl<'a> FakeDestinationInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of destination `port` property.
     pub fn port(&mut self, value: u32) -> &mut Self {
         self.destination.get_or_insert_with(Default::default).port = value;
         self
@@ -615,6 +775,7 @@ impl<'a> FakeDestinationInfoBuilder<'a> {
 }
 
 impl<'a> FakeListenerInfoBuilder<'a> {
+    /// Sets the value of listener `traffic_direction` property.
     pub fn traffic_direction(&mut self, value: TrafficDirection) -> &mut Self {
         self.listener
             .get_or_insert_with(Default::default)
@@ -624,6 +785,7 @@ impl<'a> FakeListenerInfoBuilder<'a> {
 }
 
 impl<'a> FakeRouteInfoBuilder<'a> {
+    /// Sets the value of route `name` property.
     pub fn name<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -634,6 +796,7 @@ impl<'a> FakeRouteInfoBuilder<'a> {
 }
 
 impl<'a> FakeClusterInfoBuilder<'a> {
+    /// Sets the value of cluster `name` property.
     pub fn name<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -644,6 +807,7 @@ impl<'a> FakeClusterInfoBuilder<'a> {
 }
 
 impl<'a> FakePluginInfoBuilder<'a> {
+    /// Sets the value of plugin `name` property.
     pub fn name<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -652,6 +816,7 @@ impl<'a> FakePluginInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of plugin `root_id` property.
     pub fn root_id<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,
@@ -660,6 +825,7 @@ impl<'a> FakePluginInfoBuilder<'a> {
         self
     }
 
+    /// Sets the value of plugin `vm_id` property.
     pub fn vm_id<T>(&mut self, value: T) -> &mut Self
     where
         T: AsRef<str>,

--- a/envoy-sdk-test/src/lib.rs
+++ b/envoy-sdk-test/src/lib.rs
@@ -12,6 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! `Unit Test Framework` accompanying `Rust` SDK for WebAssembly-based `Envoy` extensions.
+//!
+//! ## Supported "fakes"
+//!
+//! * [`FakeClock`]
+//! * [`FakeHttpClient`]
+//! * [`FakeStats`]
+//! * [`FakeStreamInfo`]
+//!
+//! [`FakeClock`]: host/time/index.html
+//! [`FakeHttpClient`]: host/http/client/index.html
+//! [`FakeStats`]: host/stats/index.html
+//! [`FakeStreamInfo`]: host/stream_info/index.html
+
 #![doc(html_root_url = "https://docs.rs/envoy-sdk-test/0.0.1")]
 
 pub use self::host::*;

--- a/envoy-sdk-test/tests/host/mod.rs
+++ b/envoy-sdk-test/tests/host/mod.rs
@@ -14,4 +14,5 @@
 
 mod http;
 mod stats;
+mod stream_info;
 mod time;

--- a/envoy-sdk-test/tests/host/stream_info.rs
+++ b/envoy-sdk-test/tests/host/stream_info.rs
@@ -26,7 +26,6 @@ fn test_connection() -> Result<()> {
     let fake_info = FakeStreamInfo::new().with(|info| {
         info.connection()
             .id(123)
-            .mtls(true)
             .requested_server_name("example.org")
             .tls()
             .version("TLSv1.2")

--- a/envoy-sdk-test/tests/host/stream_info.rs
+++ b/envoy-sdk-test/tests/host/stream_info.rs
@@ -1,0 +1,397 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::{Duration, SystemTime};
+
+use envoy::extension::access_logger;
+use envoy::host::stream_info::{ResponseFlags, TrafficDirection};
+use envoy::host::{HeaderMap, Result, StreamInfo};
+
+use envoy_sdk_test as envoy_test;
+use envoy_test::FakeStreamInfo;
+
+#[test]
+fn test_connection() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.connection()
+            .id(123)
+            .mtls(true)
+            .requested_server_name("example.org")
+            .tls()
+            .version("TLSv1.2")
+            .subject_local_certificate("CN=gateway")
+            .subject_peer_certificate("CN=downstream")
+            .uri_san_local_certificate("spiffe://cluster.local/gateway")
+            .uri_san_peer_certificate("spiffe://cluster.local/downstream")
+            .dns_san_local_certificate("gateway.svc")
+            .dns_san_peer_certificate("downstream.svc");
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(stream_info.connection().id()?, Some(123));
+    assert_eq!(stream_info.connection().is_mtls()?, Some(true));
+    assert_eq!(
+        stream_info.connection().requested_server_name()?,
+        Some("example.org".to_owned())
+    );
+    assert_eq!(
+        stream_info.connection().tls().version()?,
+        Some("TLSv1.2".into())
+    );
+    assert_eq!(
+        stream_info.connection().tls().subject_local_certificate()?,
+        Some("CN=gateway".into())
+    );
+    assert_eq!(
+        stream_info.connection().tls().subject_peer_certificate()?,
+        Some("CN=downstream".into())
+    );
+    assert_eq!(
+        stream_info.connection().tls().uri_san_local_certificate()?,
+        Some("spiffe://cluster.local/gateway".into())
+    );
+    assert_eq!(
+        stream_info.connection().tls().uri_san_peer_certificate()?,
+        Some("spiffe://cluster.local/downstream".into())
+    );
+    assert_eq!(
+        stream_info.connection().tls().dns_san_local_certificate()?,
+        Some("gateway.svc".into())
+    );
+    assert_eq!(
+        stream_info.connection().tls().dns_san_peer_certificate()?,
+        Some("downstream.svc".into())
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_http_request() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.request()
+            .id("a-b-c-d")
+            .time(SystemTime::UNIX_EPOCH + Duration::from_secs(12))
+            .duration(Duration::from_millis(123))
+            .size(1024)
+            .total_size(2048)
+            .method("GET")
+            .scheme("https")
+            .host("www.example.com")
+            .path("/search?q=example")
+            .protocol("HTTP/1.1")
+            .header("content-type", "application/json")
+            .header("content-length", "1001")
+            .header("user-agent", "curl")
+            .header("referer", "https://www.example.com");
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(stream_info.request().id()?, Some("a-b-c-d".to_owned()));
+    assert_eq!(
+        stream_info.request().time()?,
+        Some(SystemTime::UNIX_EPOCH + Duration::from_secs(12))
+    );
+    assert_eq!(
+        stream_info.request().duration()?,
+        Some(Duration::from_millis(123))
+    );
+    assert_eq!(stream_info.request().size()?, Some(1024));
+    assert_eq!(stream_info.request().total_size()?, Some(2048));
+    assert_eq!(stream_info.request().method()?, Some("GET".into()));
+    assert_eq!(stream_info.request().scheme()?, Some("https".into()));
+    assert_eq!(
+        stream_info.request().host()?,
+        Some("www.example.com".into())
+    );
+    assert_eq!(
+        stream_info.request().path()?,
+        Some("/search?q=example".into())
+    );
+    assert_eq!(stream_info.request().url_path()?, Some("/search".into()));
+    assert_eq!(stream_info.request().protocol()?, Some("HTTP/1.1".into()));
+    assert_eq!(
+        stream_info.request().header("content-length")?,
+        Some("1001".into())
+    );
+    assert_eq!(stream_info.request().user_agent()?, Some("curl".into()));
+    assert_eq!(
+        stream_info.request().referer()?,
+        Some("https://www.example.com".into())
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_http_response() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.response()
+            .status_code(201)
+            .header("content-type", "application/json")
+            .header("content-length", "1001")
+            .trailer("grpc-message", "UNKNOWN")
+            .size(1024)
+            .total_size(2048)
+            .grpc_status(1)
+            .response_flags(
+                ResponseFlags::FAILED_LOCAL_HEALTH_CHECK | ResponseFlags::DELAY_INJECTED,
+            );
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(stream_info.response().status_code()?, Some(201));
+    assert_eq!(stream_info.response().size()?, Some(1024));
+    assert_eq!(stream_info.response().total_size()?, Some(2048));
+    assert_eq!(stream_info.response().grpc_status()?, Some(1));
+    assert_eq!(
+        stream_info.response().flags()?,
+        Some(ResponseFlags::FAILED_LOCAL_HEALTH_CHECK | ResponseFlags::DELAY_INJECTED)
+    );
+    assert_eq!(
+        stream_info.response().header("content-type")?,
+        Some("application/json".into())
+    );
+    assert_eq!(
+        stream_info.response().trailer("grpc-message")?,
+        Some("UNKNOWN".into())
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_upstream() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.upstream()
+            .address("192.168.0.1")
+            .port(5432)
+            .local_address("127.0.0.1")
+            .transport_failure_reason("bad luck")
+            .tls()
+            .version("TLSv1.1")
+            .subject_local_certificate("CN=gateway")
+            .subject_peer_certificate("CN=upstream")
+            .uri_san_local_certificate("spiffe://cluster.local/gateway")
+            .uri_san_peer_certificate("spiffe://cluster.local/upstream")
+            .dns_san_local_certificate("gateway.svc")
+            .dns_san_peer_certificate("upstream.svc");
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(
+        stream_info.upstream().address()?,
+        Some("192.168.0.1".to_owned())
+    );
+    assert_eq!(stream_info.upstream().port()?, Some(5432));
+    assert_eq!(
+        stream_info.upstream().local_address()?,
+        Some("127.0.0.1".to_owned())
+    );
+    assert_eq!(
+        stream_info.upstream().transport_failure_reason()?,
+        Some("bad luck".to_owned())
+    );
+    assert_eq!(
+        stream_info.upstream().tls().version()?,
+        Some("TLSv1.1".into())
+    );
+    assert_eq!(
+        stream_info.upstream().tls().subject_local_certificate()?,
+        Some("CN=gateway".into())
+    );
+    assert_eq!(
+        stream_info.upstream().tls().subject_peer_certificate()?,
+        Some("CN=upstream".into())
+    );
+    assert_eq!(
+        stream_info.upstream().tls().uri_san_local_certificate()?,
+        Some("spiffe://cluster.local/gateway".into())
+    );
+    assert_eq!(
+        stream_info.upstream().tls().uri_san_peer_certificate()?,
+        Some("spiffe://cluster.local/upstream".into())
+    );
+    assert_eq!(
+        stream_info.upstream().tls().dns_san_local_certificate()?,
+        Some("gateway.svc".into())
+    );
+    assert_eq!(
+        stream_info.upstream().tls().dns_san_peer_certificate()?,
+        Some("upstream.svc".into())
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_source() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.source().address("10.0.0.1").port(50505);
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(stream_info.source().address()?, Some("10.0.0.1".to_owned()));
+    assert_eq!(stream_info.source().port()?, Some(50505));
+
+    Ok(())
+}
+
+#[test]
+fn test_destination() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.destination().address("172.0.0.1").port(15000);
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(
+        stream_info.destination().address()?,
+        Some("172.0.0.1".to_owned())
+    );
+    assert_eq!(stream_info.destination().port()?, Some(15000));
+
+    Ok(())
+}
+
+#[test]
+fn test_listener() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.listener()
+            .traffic_direction(TrafficDirection::OUTBOUND);
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(
+        stream_info.listener().traffic_direction()?,
+        Some(TrafficDirection::OUTBOUND)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_route() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.route().name("my_route");
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(stream_info.route().name()?, Some("my_route".to_owned()));
+
+    Ok(())
+}
+
+#[test]
+fn test_cluster() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.cluster().name("my_cluster");
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(stream_info.cluster().name()?, Some("my_cluster".to_owned()));
+
+    Ok(())
+}
+
+#[test]
+fn test_plugin() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.plugin()
+            .name("my_plugin")
+            .root_id("my_root_id")
+            .vm_id("my_vm_id");
+    });
+    let stream_info: &dyn StreamInfo = &fake_info;
+
+    assert_eq!(stream_info.plugin().name()?, Some("my_plugin".to_owned()));
+    assert_eq!(
+        stream_info.plugin().root_id()?,
+        Some("my_root_id".to_owned())
+    );
+    assert_eq!(stream_info.plugin().vm_id()?, Some("my_vm_id".to_owned()));
+
+    Ok(())
+}
+
+#[test]
+fn test_headers() -> Result<()> {
+    let fake_info = FakeStreamInfo::new().with(|info| {
+        info.request()
+            .method("GET")
+            .scheme("https")
+            .host("www.example.com")
+            .path("/search?q=example")
+            .protocol("HTTP/1.1")
+            .header("content-type", "application/json")
+            .header("content-length", "1001")
+            .header("user-agent", "curl")
+            .header("referer", "https://www.example.com");
+        info.response()
+            .status_code(201)
+            .header("content-type", "application/json")
+            .header("content-length", "2002")
+            .trailer("grpc-message", "UNKNOWN")
+            .size(1024)
+            .grpc_status(1);
+    });
+    let log_ops: &dyn access_logger::LogOps = &fake_info;
+
+    assert_eq!(
+        log_ops.request_headers()?,
+        HeaderMap::builder()
+            .header(":method", "GET")
+            .header(":scheme", "https")
+            .header(":authority", "www.example.com")
+            .header(":path", "/search?q=example")
+            .header("content-type", "application/json")
+            .header("content-length", "1001")
+            .header("user-agent", "curl")
+            .header("referer", "https://www.example.com")
+            .build()
+    );
+    assert_eq!(
+        log_ops.request_header("content-type")?,
+        Some("application/json".into())
+    );
+    assert_eq!(log_ops.request_header("x-custom-header")?, None);
+
+    assert_eq!(
+        log_ops.response_headers()?,
+        HeaderMap::builder()
+            .header(":status", "201")
+            .header("content-type", "application/json")
+            .header("content-length", "2002")
+            .build()
+    );
+    assert_eq!(
+        log_ops.response_header("content-length")?,
+        Some("2002".into())
+    );
+    assert_eq!(log_ops.response_header("x-custom-header")?, None);
+
+    assert_eq!(
+        log_ops.response_trailers()?,
+        HeaderMap::builder()
+            .header("grpc-message", "UNKNOWN")
+            .header("grpc-status", "1")
+            .build()
+    );
+    assert_eq!(
+        log_ops.response_trailer("grpc-message")?,
+        Some("UNKNOWN".into())
+    );
+    assert_eq!(log_ops.response_trailer("x-custom-trailer")?, None);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

* I'm splitting original PR #54 into 2 parts
* The goals are
  * simplify code review
  * make it clear that testing framework consists of 2 levels:
    * 1st level - `Fake` implementations of `Envoy Host API`s, e.g. `FakeClock`, `FakeStats`, `FakeHttpClient`, `FakeStreamInfo`; they can be used to unit test down to individual methods 
    * 2nd level - simulation of Envoy request processing flow (#53, #54, #55) to keep that knowledge (when Envoy calls one callback or another, what response to expect from Host APIs) concentrated inside the test framework itself rather that dispersed across every unit test 
