### PR TITLE
Update the proxy-wasm SDK to one for Envoy 1.17

### DIFF
--- a/envoy-sdk-test/src/host/stream_info.rs
+++ b/envoy-sdk-test/src/host/stream_info.rs
@@ -1177,7 +1177,7 @@ impl StreamInfo for FakeStreamInfo {
                 .map(Encoder::encode_str),
             _ => None,
         };
-        encoded.unwrap_or_else(|| Ok(None))
+        encoded.unwrap_or(Ok(None))
     }
 
     fn set_stream_property(&self, _path: &[&str], _value: &[u8]) -> host::Result<()> {

--- a/envoy-sdk/Cargo.toml
+++ b/envoy-sdk/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["rlib"]
 default = ["log"]
 
 [dependencies]
-proxy-wasm = { package = "proxy-wasm-experimental", version = "0.0.7" }
+proxy-wasm = { package = "proxy-wasm-experimental", version = "0.0.8" }
 anyhow = "1.0"
 bitflags = "1.2.1"
 

--- a/envoy-sdk/Cargo.toml
+++ b/envoy-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envoy-sdk"
-version = "0.2.0"
+version = "0.2.0-alpha.1"
 authors = ["Tetrate Labs <tetratelabs@tetrate.io>"]
 description = "Rust SDK for WebAssembly-based Envoy extensions"
 license = "Apache-2.0"

--- a/envoy-sdk/Cargo.toml
+++ b/envoy-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envoy-sdk"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tetrate Labs <tetratelabs@tetrate.io>"]
 description = "Rust SDK for WebAssembly-based Envoy extensions"
 license = "Apache-2.0"

--- a/envoy-sdk/Cargo.toml
+++ b/envoy-sdk/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["rlib"]
 # Default set of optional packages.
 # Most people will want to use these packages, but they are strictly optional.
 default = ["log"]
+wee-alloc = ["proxy-wasm/wee-alloc"]
 
 [dependencies]
 proxy-wasm = { package = "proxy-wasm-experimental", version = "0.0.8" }

--- a/envoy-sdk/src/extension/factory/context.rs
+++ b/envoy-sdk/src/extension/factory/context.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use proxy_wasm::types::ContextType;
-
 use super::{ContextOps, DrainStatus, ExtensionFactory, Ops};
 use crate::abi::proxy_wasm::traits::{Context, HttpContext, RootContext, StreamContext};
+use crate::abi::proxy_wasm::types::ContextType;
 use crate::extension::error::ErrorSink;
 use crate::extension::{ConfigStatus, InstanceId};
 use crate::host::ByteString;

--- a/envoy-sdk/src/extension/factory/context.rs
+++ b/envoy-sdk/src/extension/factory/context.rs
@@ -12,21 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use proxy_wasm::types::ContextType;
+
 use super::{ContextOps, DrainStatus, ExtensionFactory, Ops};
-use crate::abi::proxy_wasm::traits::{ChildContext, Context, RootContext};
+use crate::abi::proxy_wasm::traits::{Context, HttpContext, RootContext, StreamContext};
 use crate::extension::error::ErrorSink;
 use crate::extension::{ConfigStatus, InstanceId};
 use crate::host::ByteString;
+use std::cell::RefCell;
+
+pub(crate) enum ChildContextFactory<F>
+where
+    F: ExtensionFactory,
+{
+    StreamContextFactory(fn(&mut F, InstanceId) -> Box<dyn StreamContext>),
+    HttpContextFactory(fn(&mut F, InstanceId) -> Box<dyn HttpContext>),
+}
 
 pub(crate) struct ExtensionFactoryContext<'a, F>
 where
     F: ExtensionFactory,
 {
-    factory: F,
+    factory: RefCell<F>,
     context_ops: &'a dyn ContextOps,
     factory_ops: &'a dyn Ops,
     error_sink: &'a dyn ErrorSink,
-    child_context_factory: fn(&mut F, InstanceId) -> ChildContext,
+    child_context_factory: ChildContextFactory<F>,
 }
 
 impl<'a, F> RootContext for ExtensionFactoryContext<'a, F>
@@ -41,6 +52,7 @@ where
         };
         match config.and_then(|config| {
             self.factory
+                .borrow_mut()
                 .on_configure(config, self.factory_ops.as_configure_ops())
         }) {
             Ok(status) => status.as_bool(),
@@ -52,12 +64,31 @@ where
         }
     }
 
-    fn on_create_child_context(&mut self, context_id: u32) -> Option<ChildContext> {
-        let new_child_context = self.child_context_factory;
-        Some(new_child_context(
-            &mut self.factory,
-            InstanceId::from(context_id),
-        ))
+    fn get_type(&self) -> Option<ContextType> {
+        match self.child_context_factory {
+            ChildContextFactory::HttpContextFactory(_) => Some(ContextType::HttpContext),
+            ChildContextFactory::StreamContextFactory(_) => Some(ContextType::StreamContext),
+        }
+    }
+
+    fn create_http_context(&self, context_id: u32) -> Option<Box<dyn HttpContext>> {
+        match self.child_context_factory {
+            ChildContextFactory::HttpContextFactory(f) => Some(f(
+                &mut self.factory.borrow_mut(),
+                InstanceId::from(context_id),
+            )),
+            _ => None,
+        }
+    }
+
+    fn create_stream_context(&self, context_id: u32) -> Option<Box<dyn StreamContext>> {
+        match self.child_context_factory {
+            ChildContextFactory::StreamContextFactory(f) => Some(f(
+                &mut self.factory.borrow_mut(),
+                InstanceId::from(context_id),
+            )),
+            _ => None,
+        }
     }
 }
 
@@ -66,7 +97,7 @@ where
     F: ExtensionFactory,
 {
     fn on_done(&mut self) -> bool {
-        match self.factory.on_drain() {
+        match self.factory.borrow_mut().on_drain() {
             Ok(status) => status.as_bool(),
             Err(err) => {
                 self.error_sink
@@ -86,10 +117,10 @@ where
         context_ops: &'a dyn ContextOps,
         factory_ops: &'a dyn Ops,
         error_sink: &'a dyn ErrorSink,
-        child_context_factory: fn(&mut F, InstanceId) -> ChildContext,
+        child_context_factory: ChildContextFactory<F>,
     ) -> Self {
         ExtensionFactoryContext {
-            factory,
+            factory: RefCell::new(factory),
             context_ops,
             factory_ops,
             error_sink,
@@ -98,10 +129,7 @@ where
     }
 
     /// Creates a new factory context bound to the actual Envoy ABI.
-    pub fn with_default_ops(
-        factory: F,
-        child_context_factory: fn(&mut F, InstanceId) -> ChildContext,
-    ) -> Self {
+    pub fn with_default_ops(factory: F, child_context_factory: ChildContextFactory<F>) -> Self {
         Self::new(
             factory,
             ContextOps::default(),

--- a/envoy-sdk/src/extension/factory/mod.rs
+++ b/envoy-sdk/src/extension/factory/mod.rs
@@ -50,7 +50,7 @@
 use crate::extension::{factory, InstanceId, Result};
 use crate::host::{self, ByteString};
 
-pub(crate) use self::context::ExtensionFactoryContext;
+pub(crate) use self::context::{ChildContextFactory, ExtensionFactoryContext};
 
 mod context;
 mod ops;

--- a/envoy-sdk/src/extension/module/dispatcher.rs
+++ b/envoy-sdk/src/extension/module/dispatcher.rs
@@ -48,7 +48,7 @@ impl<'a> ContextSelector<'a> {
         if let Some(root_context_factory) = self.factories.get_mut(&name) {
             return root_context_factory(context_id);
         }
-        if name == "" && self.factories.keys().len() == 1 {
+        if name.is_empty() && self.factories.keys().len() == 1 {
             if let Some(root_context_factory) = self.factories.values_mut().next() {
                 return root_context_factory(context_id);
             }

--- a/envoy-sdk/src/lib.rs
+++ b/envoy-sdk/src/lib.rs
@@ -83,7 +83,7 @@
 //! [`HowToShareStats`]: extension/factory/trait.ExtensionFactory.html#examples
 //! [`HowToUseHttpClient`]: host/http/client/trait.HttpClient.html#examples
 
-#![doc(html_root_url = "https://docs.rs/envoy-sdk/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/envoy-sdk/0.2.0-alpha.1")]
 
 mod abi;
 

--- a/envoy-sdk/src/lib.rs
+++ b/envoy-sdk/src/lib.rs
@@ -83,7 +83,7 @@
 //! [`HowToShareStats`]: extension/factory/trait.ExtensionFactory.html#examples
 //! [`HowToUseHttpClient`]: host/http/client/trait.HttpClient.html#examples
 
-#![doc(html_root_url = "https://docs.rs/envoy-sdk/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/envoy-sdk/0.2.0")]
 
 mod abi;
 

--- a/examples/access-logger/docker-compose.yaml
+++ b/examples/access-logger/docker-compose.yaml
@@ -15,7 +15,7 @@
 version: '3.5'
 services:
   envoy:
-    image: yskopets/envoy-wasm:8343a96
+    image: envoyproxy/envoy:v1.17-latest
     volumes:
     - ./envoy.yaml:/etc/envoy/envoy.yaml
     - ../../target/wasm32-unknown-unknown/release/access_logger_module.wasm:/etc/envoy/access_logger_module.wasm

--- a/examples/access-logger/envoy.yaml
+++ b/examples/access-logger/envoy.yaml
@@ -45,7 +45,7 @@ static_resources:
                 route:
                   cluster: mock_service
           http_filters:
-          - name: envoy.router
+          - name: envoy.filters.http.router
           access_log:
           - name: envoy.access_loggers.wasm
             typed_config:
@@ -89,7 +89,7 @@ static_resources:
                   body:
                     inline_string: "Hi from mock service!\n"
           http_filters:
-          - name: envoy.router
+          - name: envoy.filters.http.router
 
   clusters:
   - name: mock_service

--- a/examples/access-logger/envoy.yaml
+++ b/examples/access-logger/envoy.yaml
@@ -96,7 +96,12 @@ static_resources:
     connect_timeout: 0.25s
     type: static
     lb_policy: round_robin
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 10001
+    load_assignment:
+      cluster_name: mock_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 10001

--- a/examples/http-filter/docker-compose.yaml
+++ b/examples/http-filter/docker-compose.yaml
@@ -15,7 +15,7 @@
 version: '3.5'
 services:
   envoy:
-    image: yskopets/envoy-wasm:8343a96
+    image: envoyproxy/envoy:v1.17-latest
     volumes:
     - ./envoy.yaml:/etc/envoy/envoy.yaml
     - ../../target/wasm32-unknown-unknown/release/http_filter_module.wasm:/etc/envoy/http_filter_module.wasm

--- a/examples/http-filter/envoy.yaml
+++ b/examples/http-filter/envoy.yaml
@@ -95,7 +95,12 @@ static_resources:
     connect_timeout: 0.25s
     type: static
     lb_policy: round_robin
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 10001
+    load_assignment:
+      cluster_name: mock_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 10001

--- a/examples/http-filter/envoy.yaml
+++ b/examples/http-filter/envoy.yaml
@@ -61,7 +61,7 @@ static_resources:
                   code:
                     local:
                       filename: /etc/envoy/http_filter_module.wasm
-          - name: envoy.router
+          - name: envoy.filters.http.router
 
   - name: mock
     address:
@@ -88,7 +88,7 @@ static_resources:
                   body:
                     inline_string: "Hi from mock service!\n"
           http_filters:
-          - name: envoy.router
+          - name: envoy.filters.http.router
 
   clusters:
   - name: mock_service

--- a/examples/network-filter/docker-compose.yaml
+++ b/examples/network-filter/docker-compose.yaml
@@ -15,7 +15,7 @@
 version: '3.5'
 services:
   envoy:
-    image: yskopets/envoy-wasm:8343a96
+    image: envoyproxy/envoy:v1.17-latest
     volumes:
     - ./envoy.yaml:/etc/envoy/envoy.yaml
     - ../../target/wasm32-unknown-unknown/release/network_filter_module.wasm:/etc/envoy/network_filter_module.wasm

--- a/examples/network-filter/envoy.yaml
+++ b/examples/network-filter/envoy.yaml
@@ -84,7 +84,12 @@ static_resources:
     connect_timeout: 0.25s
     type: static
     lb_policy: round_robin
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 10001
+    load_assignment:
+      cluster_name: mock_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 10001

--- a/examples/network-filter/envoy.yaml
+++ b/examples/network-filter/envoy.yaml
@@ -77,7 +77,7 @@ static_resources:
                   body:
                     inline_string: "Hi from mock service!\n"
           http_filters:
-          - name: envoy.router
+          - name: envoy.filters.http.router
 
   clusters:
   - name: mock_service


### PR DESCRIPTION
## Summary

* Update underlying version of `proxy-wasm-experimental` (see yskopets/proxy-wasm-rust-sdk#18))
  * So, this PR should be merged after the PR above.
* Update `ExtensionFactoryContext` following the upstream's mechanism to create child contexts.
  *  Links: [Yaro’s mechanism](https://github.com/yskopets/proxy-wasm-rust-sdk/commit/59ca074aa8da94df108689e04c68befd1b19d94b) and [The upstream's one](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/pull/34) 
  * See yskopets/proxy-wasm-rust-sdk#19

## Why PR draft?
~~This change depends on the new crate version of `proxy-wasm-rust-sdk` which yskopets/proxy-wasm-rust-sdk#19 introduces. This PR cannot be merged until it's completed.~~

## What's NOT done in this PR yet
* ~~The docker images used in the examples are not updated. Please let me know if it should be done in this PR as well.~~ => DONE!
