### PR TITLE
Deprecates this crate in favor of proxy-wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,7 @@
-[![Build](https://github.com/tetratelabs/envoy-wasm-rust-sdk/workflows/build/badge.svg)](https://github.com/tetratelabs/envoy-wasm-rust-sdk/actions)
-[![Crate](https://img.shields.io/crates/v/envoy-sdk.svg)](https://crates.io/crates/envoy-sdk)
-[![Docs](https://docs.rs/envoy-sdk/badge.svg)](https://docs.rs/envoy-sdk)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+# envoy-wasm-rust-sdk
 
-# Rust SDK for WebAssembly-based Envoy extensions
+This is the historical source of the "envoy-sdk" crate (Rust library).
 
-Convenience layer on top of the original [proxy-wasm](https://github.com/proxy-wasm/proxy-wasm-rust-sdk) SDK
-that brings in structure and guidance for extension developers.
+Note: **This crate is no longer maintained**.
 
-## TLDR
-
-```toml
-[dependencies]
-envoy = { package = "envoy-sdk", version = "0.1" }
-```
-
-```rust
-use envoy::extension::filter::http;
-use envoy::extension::{HttpFilter, Result};
-use envoy::host::log;
-
-/// My very own `HttpFilter`.
-struct MyHttpFilter;
-
-impl HttpFilter for MyHttpFilter {
-    /// Called when HTTP request headers have been received.
-    ///
-    /// Use `_ops` to access or mutate request headers.
-    fn on_request_headers(&mut self, _num_headers: usize, _end_of_stream: bool, _ops: &dyn http::RequestHeadersOps) -> Result<http::FilterHeadersStatus> {
-        log::info!("proxying an HTTP request");
-        Ok(http::FilterHeadersStatus::Continue)
-    }
-}
-```
-
-## Components
-
-* [envoy-sdk](./envoy-sdk/) - `Envoy SDK`
-* [envoy-sdk-test](./envoy-sdk-test/) - `Unit Test Framework` accompanying `Envoy SDK`
-* [examples](./examples/) - `Envoy SDK` usage examples
-  * [http-filter](./examples/http-filter/) - logs HTTP request/response headers, makes an outgoing HTTP request
-  * [network-filter](./examples/network-filter/) - logs start and end of a TCP conection, makes an outgoing HTTP request
-  * [access-logger](./examples/access-logger/) - logs information about an HTTP request or a TCP connection, makes an outgoing HTTP request
-
-## Latest docs (on `master`)
-
-* [envoy-sdk](https://tetratelabs.github.io/envoy-wasm-rust-sdk/envoy_sdk/)
-* [envoy-sdk-test](https://tetratelabs.github.io/envoy-wasm-rust-sdk/envoy_sdk_test/)
+Try using [proxy-wasm](https://github.com/proxy-wasm/proxy-wasm-rust-sdk).

--- a/envoy-sdk-test/Cargo.toml
+++ b/envoy-sdk-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "envoy-sdk-test"
 version = "0.0.1"
 authors = ["Tetrate Labs <tetratelabs@tetrate.io>"]
-description = "Rust SDK for WebAssembly-based Envoy extensions"
+description = "Deprecated. Rust SDK for WebAssembly-based Envoy extensions"
 license = "Apache-2.0"
 repository = "https://github.com/tetratelabs/envoy-wasm-rust-sdk/"
 readme = "README.md"
@@ -20,3 +20,8 @@ envoy = { path = "../envoy-sdk", package = "envoy-sdk" }
 
 [dev-dependencies]
 version-sync = "0.9"
+
+[badges]
+# Note: This is not used by crates.io, yet. The only way to change crates.io at the moment is yanking.
+# See https://github.com/rust-lang/crates.io/issues/2437
+maintenance = { status = "deprecated" }

--- a/envoy-sdk/Cargo.toml
+++ b/envoy-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "envoy-sdk"
 version = "0.2.0-alpha.1"
 authors = ["Tetrate Labs <tetratelabs@tetrate.io>"]
-description = "Rust SDK for WebAssembly-based Envoy extensions"
+description = "Deprecated. Try proxy-wasm instead"
 license = "Apache-2.0"
 repository = "https://github.com/tetratelabs/envoy-wasm-rust-sdk/"
 readme = "README.md"
@@ -31,3 +31,8 @@ log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"
+
+[badges]
+# Note: This is not used by crates.io, yet. The only way to change crates.io at the moment is yanking.
+# See https://github.com/rust-lang/crates.io/issues/2437
+maintenance = { status = "deprecated" }


### PR DESCRIPTION
This crate both depends on a personal library and is also unmaintained.

Envoy users should be pointed to a maintained repository instead.

Currently [proxy-wasm](https://github.com/proxy-wasm/proxy-wasm-rust-sdk) is maintained with recent releases by @PiotrSikora. While this includes some functionality not present there, maintained and without personal dependencies is a better path for users than otherwise.

See #70